### PR TITLE
parameter to keep unmatched annotations

### DIFF
--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -48,7 +48,9 @@ def eval_expression(
         return False
 
 
-def filter_vcf(vcf: VariantFile, expression: str, keep_unmatched:bool=False) -> Iterator[VariantRecord]:
+def filter_vcf(
+    vcf: VariantFile, expression: str, keep_unmatched: bool = False
+) -> Iterator[VariantRecord]:
     header = vcf.header
 
     env = dict()
@@ -125,5 +127,7 @@ def main():
         elif args.output_fmt == "uncompressed-bcf":
             fmt = "u"
         with VariantFile(args.output, "w" + fmt, header=vcf.header) as out:
-            for record in filter_vcf(vcf, args.expression, keep_unmatched=args.keep_unmatched):
+            for record in filter_vcf(
+                vcf, args.expression, keep_unmatched=args.keep_unmatched
+            ):
                 out.write(record)

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -116,7 +116,7 @@ def main():
         "--keep-unmatched",
         default=False,
         action="store_true",
-        help="Keep all annotations of a variant if at least one annotation pass the expression.",
+        help="Keep all annotations of a variant if at least one of them passes the expression.",
     )
     args = parser.parse_args()
 

--- a/vembrane/__init__.py
+++ b/vembrane/__init__.py
@@ -25,7 +25,7 @@ globals_whitelist = {
         "__doc__": None,
         "__package__": None,
     },
-    **{mod.__name__: mod for mod in [any, all, min, max, re, list, dict, zip,]},
+    **{mod.__name__: mod for mod in [any, all, min, max, re, list, dict, zip]},
     **{name: mod for name, mod in vars(math).items() if not name.startswith("__")},
 }
 
@@ -124,7 +124,7 @@ def main():
         "--output-fmt",
         "-O",
         default="vcf",
-        choices=["vcf", "bcf", "uncompressed-bcf",],
+        choices=["vcf", "bcf", "uncompressed-bcf"],
         help="Output format.",
     )
     parser.add_argument(


### PR DESCRIPTION
this parameter let annotations unchanged and only removes variants, when no annotation passes the expression
when "--keep-unmatched" is enabled, vembrane now behaves like filter_vep (where you can remove annotations by its "only_matched" flag).