### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.8
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^tests/.*
+      - id: end-of-file-fixer
+        exclude: ^tests/.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ pysam = "^0.16"
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 pyyaml = "^5.3"
+pre-commit = "^1.10"
+black = { version = "^19.10b0", python = "^3.7" }
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
If you're lazy like me, this PR is for you!
Just

1. make sure `pre-commit` is installed on your machine / in your env (should be available in pip, conda, archlinux repos, ...)
2. run `pre-commit install`. This will activate pre-commit hooks to your _local_ .git

et voilà! Automatic formatting with `black`, `flake8` check, trailing whitespace removal and trailing newline addition (if needed).
There are [quite some more available actions](https://pre-commit.com/hooks.html) (perhaps even use [isort](https://github.com/timothycrosley/isort) though I think I remember reading somewhere that this might lead to issues with `black`?)